### PR TITLE
feat: working on edit

### DIFF
--- a/frontend/app/(auth)/api/auth/[...nextauth]/authOptions.ts
+++ b/frontend/app/(auth)/api/auth/[...nextauth]/authOptions.ts
@@ -1,3 +1,4 @@
+import { getToken } from "next-auth/jwt"
 import { SuccessfulLoginResponse } from "@/lib/api/web-api-client"
 import { NextAuthOptions } from "next-auth"
 import CredentialsProvider from "next-auth/providers/credentials"
@@ -38,14 +39,14 @@ export const authOptions: NextAuthOptions = {
 
   pages: {},
 
-  session: {
-    strategy: "jwt",
-  },
-
   callbacks: {
     jwt: async ({ token, user }) => {
       token.apiToken = user.token
-      return token
+      return { ...token, ...user }
+    },
+    async session({ session, token, user }) {
+      session.user.token = token
+      return session
     },
   },
 }

--- a/frontend/app/(projectlevel)/[projectId]/settings/page.tsx
+++ b/frontend/app/(projectlevel)/[projectId]/settings/page.tsx
@@ -1,9 +1,30 @@
+import ProjectCard from "@/app/(orglevel)/projects/project-card"
 import MainContainer from "@/components/main-container"
 
-export default function ProjectSettingsPage() {
+const getProgect = async (id: number, token?: string) => {
+  const data = await fetch(`https://api.kwikdeploy.com/projects/${id}`, {
+    // in case we could retrieve the token from the session we could add it 
+    // or fix the middlewere so when calling /backendapi/projects 
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  })
+  const project = await data.json()
+  return project
+}
+import { getSession } from "@/lib/getSession"
+export default async function ProjectSettingsPage({
+  params,
+}: {
+  params: { projectId: string }
+}) {
+  // const session = getSession()
+  const project = await getProgect(parseInt(params.projectId))
+  console.log(project)
+
   return (
     <MainContainer props={{ className: "" }}>
-      <h1>Project Settings Page goes here</h1>
+      <ProjectCard projectId={0} />
     </MainContainer>
   )
 }

--- a/frontend/lib/getSession.ts
+++ b/frontend/lib/getSession.ts
@@ -1,0 +1,8 @@
+import { authOptions } from "@/app/(auth)/api/auth/[...nextauth]/authOptions"
+import { getServerSession } from "next-auth/next"
+
+export async function getSession() {
+  return await getServerSession(authOptions)
+}
+
+export default async function getCurrentUser() {}

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -33,6 +33,7 @@ export async function middleware(request: NextRequest) {
     if (token) {
       requestHeaders.set("Authorization", `Bearer ${token.apiToken}`)
     }
+    console.log(requestHeaders)
 
     let url = request.nextUrl.clone()
     url.protocol = scheme


### PR DESCRIPTION
The branch feat is for 

- implementing editing of a project 
- create a file to retrieve the session including the jwt and the user 

ISSUE
- the intent to use the serve component is limited to the next-auth lib.
- not possible to retrieve the session `http://localhost:3000/api/auth/session` it returns an empty obj
- I investigate the middleware where I can the jwt is present but when I try to use getServerSession I have this error 
- investigate the authOption and add the session callback but still, the problem persists


![Screenshot 2023-10-16 at 13 27 26](https://github.com/KwikDeploy/kwikdeploy/assets/5269740/2904200e-cd05-4232-a399-fe5ea4996eb8)

